### PR TITLE
Update to latest zig

### DIFF
--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -105,7 +105,7 @@ syn keyword zigBuiltin @cDefine @cImport @cInclude @cUndef
 syn keyword zigType anyerror anyframe anyopaque anytype
 syn keyword zigType bool
 syn keyword zigType comptime_float comptime_int
-syn keyword zigType f16 f32 f64 f128
+syn keyword zigType f16 f32 f64 f80 f128
 syn keyword zigType isize usize
 syn keyword zigType noreturn
 syn keyword zigType type

--- a/syntax/zig.vim
+++ b/syntax/zig.vim
@@ -74,7 +74,7 @@ syn keyword zigBuiltin @hasDecl
 syn keyword zigBuiltin @import
 syn keyword zigBuiltin @intToEnum @intToError @intToFloat @intToPtr
 syn keyword zigBuiltin @log @log2 @log10
-syn keyword zigBuiltin @maximum @minimum
+syn keyword zigBuiltin @max @min
 syn keyword zigBuiltin @memcpy @memset
 syn keyword zigBuiltin @mod @rem
 syn keyword zigBuiltin @mulAdd
@@ -87,7 +87,7 @@ syn keyword zigBuiltin @setAlignStack @setCold
 syn keyword zigBuiltin @setEvalBranchQuota @setFloatMode @setRuntimeSafety
 syn keyword zigBuiltin @shlExact @shrExact @shlWithOverflow
 syn keyword zigBuiltin @shuffle
-syn keyword zigBuiltin @sin @cos @tan
+syn keyword zigBuiltin @sin @cos
 syn keyword zigBuiltin @sqrt
 syn keyword zigBuiltin @src
 syn keyword zigBuiltin @tagName


### PR DESCRIPTION
There are the changes I'd like applied to your branch before merging into `ziglang/zig.vim` master. I'd also like to ask about highlighting operators: is that something you intentionally left out? I don't mind not having them highlighted, but it would be a feature loss. I would be okay with saying that some operators (like the `!` in the error set union type and `!` boolean negation are ambiguous and require more complex processing (say, from `tree-sitter)` to appropriately be colored